### PR TITLE
RNMT-3282 Remove close view

### DIFF
--- a/pandora-core/src/main/java/tech/linjiang/pandora/ui/view/FuncView.java
+++ b/pandora-core/src/main/java/tech/linjiang/pandora/ui/view/FuncView.java
@@ -66,10 +66,6 @@ public class FuncView extends LinearLayout {
         addView(recyclerView, new LayoutParams(
                 0, ViewGroup.LayoutParams.MATCH_PARENT, 1
         ));
-        addView(closeView, new LayoutParams(
-                ViewKnife.dip2px(40), ViewGroup.LayoutParams.MATCH_PARENT
-        ));
-
     }
 
     @Override

--- a/pandora-core/src/main/res/values/strings.xml
+++ b/pandora-core/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="pd_can_not_edit">can not edit</string>
     <string name="pd_please_open_net_log">TURN ON THE SWITCH TO LOG</string>
     <string name="pd_permission_title">Permission Denied</string>
-    <string name="pd_please_allow_permission">Pandora needs OVERLAY permission to show the function panel, %s please check and click allow.</string>
+    <string name="pd_please_allow_permission">Pandora needs OVERLAY permission to show the function panel, please check and click allow.</string>
     <string name="pd_permission_not_sure">Pandora needs OVERLAY permission to show the function panel, but not certain whether it is authorized, please check and click allow.</string>
     <string name="pd_help_title">Hint</string>
     <string name="pd_help_operate">① Single tap to select views, cancel select when tap again.\n② Long press to start moving the selected view.\n③ Click the panel to see attributes.\n④ Drag the panel to see more.\n⑤ Press back to exit.</string>


### PR DESCRIPTION
## Description
<!--- Provide a small description of the problem in hands -->
Reduces the size of the toolbar and does not allow it to be closed. In conjunction with showing the toolbar at the Inspector Plugin initialization we end up with an always visible button.

This is just to allow a temporary activation solution. These changes are easy to revert.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-3280

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Tests

## Screenshots (if appropriate)
<img width="431" src="https://user-images.githubusercontent.com/2512515/67675718-bf743800-f977-11e9-8b50-7485a52b27fb.png">
 
<img width="431" src="https://user-images.githubusercontent.com/2512515/67675839-11b55900-f978-11e9-9b4c-7975931c0ac9.png">


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly