### PR TITLE
RNMT-3515 Close toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixes
+- Re-add close button [RNMT-3515](https://outsystemsrd.atlassian.net/browse/RNMT-3515)
+
+## [v2.0.6-OS]
+### Fixes
+- Remove leftover placeholder from string [RNMT-3282](https://outsystemsrd.atlassian.net/browse/RNMT-3282)
+
+### Removals
+- Remove buttons for features we do not support [RNMT-3280](https://outsystemsrd.atlassian.net/browse/RNMT-3280)
+
+[Unreleased]: https://github.com/OutSystems/pandora/compare/v2.0.6-OS...outsystems
+[v2.0.6-OS]: https://github.com/OutSystems/pandora/compare/v2.0.6...v2.0.6-OS

--- a/pandora-core/src/main/java/tech/linjiang/pandora/ui/view/FuncView.java
+++ b/pandora-core/src/main/java/tech/linjiang/pandora/ui/view/FuncView.java
@@ -66,6 +66,10 @@ public class FuncView extends LinearLayout {
         addView(recyclerView, new LayoutParams(
                 0, ViewGroup.LayoutParams.MATCH_PARENT, 1
         ));
+        addView(closeView, new LayoutParams(
+                ViewKnife.dip2px(40), ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+
     }
 
     @Override


### PR DESCRIPTION
## Description
<!--- Provide a small description of the problem in hands -->
Now that there will be a way to manually activate Pandora, re-adding the close button is back on the table.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
References https://outsystemsrd.atlassian.net/browse/RNMT-3515

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Tests
Manual testing

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly