### PR TITLE
RNMT-3855 Remove OkUrlFactory to avoid the known issue when using HttpUrlConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changes
+- The usage of the deprecated OkUrlFactory was disabled [RNMT-3855](https://outsystemsrd.atlassian.net/browse/RNMT-3855)
 
 ## [v2.0.6-OS2]
 ### Fixes

--- a/pandora-core/src/main/java/tech/linjiang/pandora/network/okhttp3/OkUrlFactory.java
+++ b/pandora-core/src/main/java/tech/linjiang/pandora/network/okhttp3/OkUrlFactory.java
@@ -32,7 +32,13 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
   public static void init() {
     OkHttpClient client = new OkHttpClient.Builder().build();
     OkUrlFactory okUrlFactory = new OkUrlFactory(client);
-    URL.setURLStreamHandlerFactory(okUrlFactory);
+
+    /**
+     * RNMT-3855 - The usage of the OkUrlFactory was causing some network requests to fail,
+     * due to a deadlock related with StreamedRequestBody which requires to open a connection
+     * before starting the request.
+     */
+    //URL.setURLStreamHandlerFactory(okUrlFactory);
   }
 
   private OkHttpClient client;


### PR DESCRIPTION
## Description
<!--- Provide a small description of the problem in hands -->
This PR introduces the required changes to disable the usage of OkUrlFactory when using the HttpUrlConnection for network requests.
The usage of the OkUrlFactory was causing some network requests to fail, due to a deadlock related with StreamedRequestBody which requires to open a connection before starting the request.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-3855

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly